### PR TITLE
manually add people who provided incorrect data in their PRs

### DIFF
--- a/signed/people_with_incorrect_signatures_1.txt
+++ b/signed/people_with_incorrect_signatures_1.txt
@@ -1,0 +1,9 @@
+Федотов Алексей | Программист, Москва
+Бондарюк Андрей | grotem.ru, Saint-Petersburg
+Роман Евдокимов | Программист, Ceramic 3d Екатеринбург
+Зубрилин Константин | Программист, pravoved.ru
+Кириченко Анна | Data Scientist, ADV Laboratory
+Денис Самсонов | Сетевой администратор, Mail.ru
+Рудской Влад | Project Manager, Yandex
+Александр Желудков | senior software engineer, Санкт-Петербург
+Горбенко Павел | программист dotnet


### PR DESCRIPTION
Adding people from #1201, #1228, #1230, #1243, #1355, #1393, #1423, #1461, #1517. Those can be closed if this one is merged.

There's still a chance they'll fix their own PRs, of course, but I think we should prioritise cleaning up [at some point at least].